### PR TITLE
Replace security NSDictionary with FSSecurity

### DIFF
--- a/src/ios/FilePickerIO.m
+++ b/src/ios/FilePickerIO.m
@@ -53,11 +53,7 @@ FSConfig *config;
     storeOptions.container = [command.arguments objectAtIndex:7];
     storeOptions.access = [command.arguments objectAtIndex:8];
     if ([command.arguments objectAtIndex:9] && [command.arguments objectAtIndex:10]) {
-        NSDictionary *security = @{
-            @"policy" : [command.arguments objectAtIndex:9],
-            @"signature" : [command.arguments objectAtIndex:10]
-        };
-        storeOptions.security = security;
+        storeOptions.security = [[FSSecurity alloc] initWithPolicy: [command.arguments objectAtIndex:9] signature:[command.arguments objectAtIndex:10]];
     }
     
     [self showPicker: command storeOptions:storeOptions];


### PR DESCRIPTION
Hey try this instead.  I just threw a dictionary literal at it before, but it looks like its a class that needs to be initialized with policy and signature.

https://github.com/filestack/FSPicker/tree/1.1.8#fssecurity-class